### PR TITLE
Allow "Original" render mode in 480p configurations

### DIFF
--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -3223,10 +3223,6 @@ static int MenuSettingsVideo()
 		{
 			firstRun = false;
 
-			// don't allow original render mode if progressive video mode detected
-			if (GCSettings.render==0 && progressive)
-				GCSettings.render++;
-
 			if (GCSettings.render == 0)
 				sprintf (options.value[0], "Original");
 			else if (GCSettings.render == 1)


### PR DESCRIPTION
Allows us to use Original (240p) rendering mode in 480p configurations (when the "TV Resolution" setting in Wii Settings is set to "EDTV or HDTV (480p)").
It is based in Snes9x RX.