### PR TITLE
Fix mistake with render settings in Filtered (Sharp/Soft)

### DIFF
--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -3234,9 +3234,9 @@ static int MenuSettingsVideo()
 			else if (GCSettings.render == 2)
 				sprintf (options.value[0], "Unfiltered");
 			else if (GCSettings.render == 3)
-				sprintf (options.value[0], "Filtered (Sharp)");
-			else if (GCSettings.render == 4)
 				sprintf (options.value[0], "Filtered (Soft)");
+			else if (GCSettings.render == 4)
+				sprintf (options.value[0], "Filtered (Sharp)");
 
 			if(GCSettings.widescreen)
 				sprintf (options.value[1], "16:9 Correction");


### PR DESCRIPTION
By any reason FCEURX has an issue that when i set the "Render" setting to "Filtered (Sharp)" and return to the game it displays in "Soft", and when i set the "Render" setting to "Filtered (Soft)" and return to the game it displays in "Sharp".
This modification fixes that.